### PR TITLE
Extends mock api for handling of bookings.

### DIFF
--- a/src/api/mockApi/bookings.js
+++ b/src/api/mockApi/bookings.js
@@ -1,0 +1,284 @@
+export var bookings = [
+    {
+        id: 1,
+        status: {
+            description: "pending"
+        },
+        start_date: "2024-06-13",
+        product: {
+            id: 26,
+            name: "woman-only",
+            description: "2-bäddsrum för kvinnor",
+            total_places: 2,
+            host: {
+                region: {
+                    id: 3,
+                    name: "Stockholm City"
+                },
+                id: 3,
+                name: "Grimmans Akutboende",
+                street: "Parkgatan 48",
+                postcode: "",
+                city: "Sundbyberg"
+            },
+            type: "woman-only"
+        },
+        user: {
+            region: {
+                id: 2,
+                name: "Farsta"
+            },
+            id: 1,
+            user: 11,
+            first_name: "Katarina",
+            last_name: "Davidsson",
+            gender: "K",
+            street: "Kvarntorget 9",
+            postcode: "",
+            city: "Handen",
+            country: "",
+            phone: "0705-434613",
+            email: "katarina.davidsson@hotmejl.se",
+            unokod: "6871",
+            day_of_birth: null,
+            personnr_lastnr: "",
+            requirements: null,
+            last_edit: "2024-06-05"
+        }
+    },
+    {
+        id: 2,
+        status: {
+            description: "pending"
+        },
+        start_date: "2024-07-21",
+        product: {
+            id: 25,
+            name: "room",
+            description: "2-bäddsrum",
+            total_places: 2,
+            host: {
+                region: {
+                        id: 3,
+                        name: "Stockholm City"
+                },
+                id: 3,
+                name: "Grimmans Akutboende",
+                street: "Parkgatan 48",
+                postcode: "",
+                city: "Sundbyberg"
+            },
+            type: "room"
+        },
+        user: {
+            region: {
+                id: 2,
+                name: "Farsta"
+                },
+                id: 3,
+                user: 13,
+                first_name: "Stefan",
+                last_name: "Johansson",
+                gender: "M",
+                street: "Kyrkogränd 6",
+                postcode: "",
+                city: "Handen",
+                country: "",
+                phone: "0701-401093",
+                email: "stefan.johansson@hotmejl.se",
+                unokod: "5246",
+                day_of_birth: null,
+                personnr_lastnr: "",
+                requirements: null,
+                last_edit: "2024-05-05"
+        }
+    },
+    {
+        id: 3,
+        status: {
+            description: "pending"
+        },
+        start_date: "2024-08-01",
+        product: {
+            id: 45,
+            name: "room",
+            description: "5-bäddsrum",
+            total_places: 5,
+            host: {
+                region: {
+                    id: 3,
+                    name: "Stockholm City"
+                },
+                id: 3,
+                name: "Grimmans Akutboende",
+                street: "Parkgatan 48",
+                postcode: "",
+                city: "Sundbyberg"
+            },
+            type: "room"
+        },
+        user: {
+            region: {
+                id: 3,
+                name: "Stockholm City"
+            },
+            id: 6,
+            user: 16,
+            first_name: "Marie-Louise",
+            last_name: "Eriksson",
+            gender: "K",
+            street: "Skolstigen 9",
+            postcode: "",
+            city: "Stockholm",
+            country: "",
+            phone: "0701-465846",
+            email: "marie-louise.eriksson@hotmejl.se",
+            unokod: "1019",
+            day_of_birth: null,
+            personnr_lastnr: "",
+            requirements: null,
+            last_edit: "2024-05-23"
+        }
+    },
+    {
+        id: 4,
+        status: {
+            description: "pending"
+        },
+        start_date: "2024-08-03",
+        product: {
+            id: 25,
+            name: "room",
+            description: "2-bäddsrum",
+            total_places: 2,
+            host: {
+                region: {
+                        id: 3,
+                        name: "Stockholm City"
+                },
+                id: 3,
+                name: "Grimmans Akutboende",
+                street: "Parkgatan 48",
+                postcode: "",
+                city: "Sundbyberg"
+            },
+            type: "room"
+        },
+        user: {
+            region: {
+                id: 2,
+                name: "Farsta"
+                },
+                id: 3,
+                user: 13,
+                first_name: "Stefan",
+                last_name: "Johansson",
+                gender: "M",
+                street: "Kyrkogränd 6",
+                postcode: "",
+                city: "Handen",
+                country: "",
+                phone: "0701-401093",
+                email: "stefan.johansson@hotmejl.se",
+                unokod: "5246",
+                day_of_birth: null,
+                personnr_lastnr: "",
+                requirements: null,
+                last_edit: "2024-05-05"
+        }
+    },
+    {
+        id: 5,
+        status: {
+            description: "pending"
+        },
+        start_date: "2024-08-04",
+        product: {
+            id: 45,
+            name: "room",
+            description: "5-bäddsrum",
+            total_places: 5,
+            host: {
+                region: {
+                    id: 3,
+                    name: "Stockholm City"
+                },
+                id: 3,
+                name: "Grimmans Akutboende",
+                street: "Parkgatan 48",
+                postcode: "",
+                city: "Sundbyberg"
+            },
+            type: "room"
+        },
+        user: {
+            region: {
+                id: 3,
+                name: "Stockholm City"
+            },
+            id: 6,
+            user: 16,
+            first_name: "Marie-Louise",
+            last_name: "Eriksson",
+            gender: "K",
+            street: "Skolstigen 9",
+            postcode: "",
+            city: "Stockholm",
+            country: "",
+            phone: "0701-465846",
+            email: "marie-louise.eriksson@hotmejl.se",
+            unokod: "1019",
+            day_of_birth: null,
+            personnr_lastnr: "",
+            requirements: null,
+            last_edit: "2024-05-23"
+        }
+    },
+    {
+        id: 6,
+        status: {
+            description: "pending"
+        },
+        start_date: "2024-08-06",
+        product: {
+            id: 45,
+            name: "room",
+            description: "5-bäddsrum",
+            total_places: 5,
+            host: {
+                region: {
+                    id: 3,
+                    name: "Stockholm City"
+                },
+                id: 3,
+                name: "Grimmans Akutboende",
+                street: "Parkgatan 48",
+                postcode: "",
+                city: "Sundbyberg"
+            },
+            type: "room"
+        },
+        user: {
+            region: {
+                id: 3,
+                name: "Stockholm City"
+            },
+            id: 6,
+            user: 16,
+            first_name: "Marie-Louise",
+            last_name: "Eriksson",
+            gender: "K",
+            street: "Skolstigen 9",
+            postcode: "",
+            city: "Stockholm",
+            country: "",
+            phone: "0701-465846",
+            email: "marie-louise.eriksson@hotmejl.se",
+            unokod: "1019",
+            day_of_birth: null,
+            personnr_lastnr: "",
+            requirements: null,
+            last_edit: "2024-05-23"
+        }
+    }
+];


### PR DESCRIPTION
This change adds mock api for following backend APIs.
- /api/host/pending/{booking_id}
- /api/host/pending/{booking_id}/appoint
- /api/host/pending/{booking_id}/decline

mock APIs will modify the mocked bookings list the same way as backend handles the bookings.