### PR TITLE
520 skapa sidomeny fr handlggare

### DIFF
--- a/src/components/Sidebar/GetMenuItems.js
+++ b/src/components/Sidebar/GetMenuItems.js
@@ -1,10 +1,7 @@
 import {
-    FaCog,
     FaChartPie,
     FaReceipt,
-    FaUserAlt,
     FaBell,
-    FaSignOutAlt,
     FaUser,
     FaRandom,
     FaCalendarAlt,

--- a/src/components/Sidebar/GetMenuItems.js
+++ b/src/components/Sidebar/GetMenuItems.js
@@ -1,0 +1,44 @@
+import {
+    FaCog,
+    FaChartPie,
+    FaReceipt,
+    FaUserAlt,
+    FaBell,
+    FaSignOutAlt,
+    FaUser,
+    FaRandom,
+    FaCalendarAlt,
+  } from "react-icons/fa";
+
+export default function GetMenuItems(userGroup) {
+    const hostSidebarItemsTop = [
+        { icon: FaChartPie, label: "Överblick", sideBarLink: "host" },
+        { icon: FaBell, label: "Förfrågningar", sideBarLink: "host/requests" },
+        { icon: FaCalendarAlt, label: "Kalender" },
+        { icon: FaRandom, label: "Mina Rum", sideBarLink: "host/products" },
+        { icon: FaRandom, label: "Härberget" },
+        { icon: FaUser, label: "Gäster" },
+        { icon: FaReceipt, label: "Fakturering" },
+    ];
+
+    const caseworkerSidebarItemsTop = [
+        { icon: FaChartPie, label: "Överblick", sideBarLink: "caseworker" },
+        { icon: FaBell, label: "Förfrågningar", sideBarLink: "caseworker/requests" },
+        { icon: FaRandom, label: "Mina Rum", sideBarLink: "caseworker/products" },
+        { icon: FaUser, label: "Gäster" },
+    ];
+
+    const userSidebarItemsTop = [
+        { icon: FaChartPie, label: "Överblick", sideBarLink: "user" },
+        { icon: FaBell, label: "Bokningar", sideBarLink: "user/requests" },
+    ];
+
+
+    if (userGroup == "caseworker") {
+        return caseworkerSidebarItemsTop;
+    } else if (userGroup == "host") {
+        return hostSidebarItemsTop;
+    } else {
+        return userSidebarItemsTop;
+    }
+}

--- a/src/components/Sidebar/GetMenuItems.js
+++ b/src/components/Sidebar/GetMenuItems.js
@@ -24,8 +24,8 @@ export default function GetMenuItems(userGroup) {
     const caseworkerSidebarItemsTop = [
         { icon: FaChartPie, label: "Överblick", sideBarLink: "caseworker" },
         { icon: FaBell, label: "Förfrågningar", sideBarLink: "caseworker/requests" },
-        { icon: FaRandom, label: "Mina Rum", sideBarLink: "caseworker/products" },
-        { icon: FaUser, label: "Gäster" },
+        { icon: FaRandom, label: "Hantera Användare", sideBarLink: "caseworker/users" },
+        { icon: FaUser, label: "Statistik för boenden", sideBarLink: "caseworker/statistics" },
     ];
 
     const userSidebarItemsTop = [

--- a/src/components/Sidebar/GetMenuItems.js
+++ b/src/components/Sidebar/GetMenuItems.js
@@ -8,6 +8,7 @@ import {
     FaUser,
     FaRandom,
     FaCalendarAlt,
+    FaChartBar,
   } from "react-icons/fa";
 
 export default function GetMenuItems(userGroup) {
@@ -24,8 +25,8 @@ export default function GetMenuItems(userGroup) {
     const caseworkerSidebarItemsTop = [
         { icon: FaChartPie, label: "Överblick", sideBarLink: "caseworker" },
         { icon: FaBell, label: "Förfrågningar", sideBarLink: "caseworker/requests" },
-        { icon: FaRandom, label: "Hantera Användare", sideBarLink: "caseworker/users" },
-        { icon: FaUser, label: "Statistik för boenden", sideBarLink: "caseworker/statistics" },
+        { icon: FaUser, label: "Användare", sideBarLink: "caseworker/users" },
+        { icon: FaChartBar, label: "Statistik", sideBarLink: "caseworker/statistics" },
     ];
 
     const userSidebarItemsTop = [

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,14 +1,8 @@
 import React from "react";
 import {
   FaCog,
-  FaChartPie,
-  FaReceipt,
   FaUserAlt,
-  FaBell,
   FaSignOutAlt,
-  FaUser,
-  FaRandom,
-  FaCalendarAlt,
 } from "react-icons/fa";
 import useLogin from "./../../hooks/useLogin";
 import { useNavigate } from "react-router-dom";

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -10,11 +10,14 @@ import {
   FaRandom,
   FaCalendarAlt,
 } from "react-icons/fa";
+import useLogin from "./../../hooks/useLogin";
 import { useNavigate } from "react-router-dom";
 import noQicon from "./../../assets/images/noQiconNoQGreen.svg";
+import GetMenuItems from "./GetMenuItems";
 
 export default function Sidebar() {
   const navigate = useNavigate();
+  const { login } = useLogin();
 
   const liStyle =
     "py-5 text-gray-500 border-green-noQ hover:bg-green-noQ hover:text-white transition-colors duration-200 rounded-2xl";
@@ -29,15 +32,7 @@ export default function Sidebar() {
     window.location.reload();
   };
 
-  const sidebarItemsTop = [
-    { icon: FaChartPie, label: "Överblick", sideBarLink: "host" },
-    { icon: FaBell, label: "Förfrågningar", sideBarLink: "host/requests" },
-    { icon: FaCalendarAlt, label: "Kalender" },
-    { icon: FaRandom, label: "Mina Rum", sideBarLink: "host/products" },
-    { icon: FaRandom, label: "Härberget" },
-    { icon: FaUser, label: "Gäster" },
-    { icon: FaReceipt, label: "Fakturering" },
-  ];
+  const sidebarItemsTop = GetMenuItems(login.usergroups[0]);
 
   const sidebarItemsBottom = [
     { icon: FaCog, label: "Inställningar" },


### PR DESCRIPTION
This PR creates different menus for user, host and caseworker. User menu is not in use yet in the user page, but the logic is there. Following changes have been made:
- Moved menu data for top items to a separate function, that will git data based on user
- Updated sidebar file with loginHook and check for usergroup of the logged in user