### PR TITLE
Fixes issue with not setting config for Overview page for host

### DIFF
--- a/src/components/RequestsPage/GetBookingConfig.js
+++ b/src/components/RequestsPage/GetBookingConfig.js
@@ -1,0 +1,25 @@
+export const GetBookingConfig = (userGroup) => {
+
+    let bookingConfig = null;
+        
+    if (userGroup == "host") {
+        bookingConfig = {
+            fetchUrl: "/api/host/pending",
+            assignUrl: (bookingId) => `/api/host/pending/${bookingId}/appoint`,
+            batchAssignUrl:"/api/host/pending/batch/accept",
+            rejectUrl: (bookingId) => `/api/host/pending/${bookingId}/decline`,
+            undoUrl: (bookingId) => `/api/host/bookings/${bookingId}/setpending`
+        };    
+    } else if (userGroup == "caseworker") {
+        bookingConfig = {
+            fetchUrl: "/api/caseworker/bookings/pending",
+            assignUrl: (bookingId) => `/api/caseworker/bookings/${bookingId}/accept`,
+            batchAssignUrl:"/api/caseworker/bookings/batch/accept",
+            rejectUrl: (bookingId) => `/api/caseworker/bookings/${bookingId}/decline`,
+            undoUrl: (bookingId) => `/api/caseworker/bookings/${bookingId}/setpending`
+        };
+    } else {
+        console.log("Invalid userGroup for RequestPageView.");
+    }
+    return bookingConfig;
+}

--- a/src/components/RequestsPage/RequestPageView.jsx
+++ b/src/components/RequestsPage/RequestPageView.jsx
@@ -2,6 +2,7 @@ import { React } from 'react';
 import PropTypes from "prop-types";
 import RequestList from './RequestList';
 import useHeader from "./../../hooks/useHeader";
+import { GetBookingConfig } from './GetBookingConfig';
 
 export default function RequestPageView({userGroup}) {
     const { setHeader } = useHeader();
@@ -11,27 +12,7 @@ export default function RequestPageView({userGroup}) {
         userGroup: PropTypes.string.isRequired
     };
 
-    let bookingConfig = null
-
-    if (userGroup == "host") {
-        bookingConfig = {
-            fetchUrl: "/api/host/pending",
-            assignUrl: (bookingId) => `/api/host/pending/${bookingId}/appoint`,
-            batchAssignUrl:"/api/host/pending/batch/accept",
-            rejectUrl: (bookingId) => `/api/host/pending/${bookingId}/decline`,
-            undoUrl: (bookingId) => `/api/host/bookings/${bookingId}/setpending`
-        };    
-    } else if (userGroup == "caseworker") {
-        bookingConfig = {
-            fetchUrl: "/api/caseworker/bookings/pending",
-            assignUrl: (bookingId) => `/api/caseworker/bookings/${bookingId}/accept`,
-            batchAssignUrl:"/api/caseworker/bookings/batch/accept",
-            rejectUrl: (bookingId) => `/api/caseworker/bookings/${bookingId}/decline`,
-            undoUrl: (bookingId) => `/api/caseworker/bookings/${bookingId}/setpending`
-        };
-    } else {
-        console.log("Invalid userGroup for RequestPageView.");
-    }
+    const bookingConfig = GetBookingConfig(userGroup);
 
     return (
         <div className='p-4'>

--- a/src/pages/HostPage.jsx
+++ b/src/pages/HostPage.jsx
@@ -9,6 +9,7 @@ import OutgoingGuests from "../components/Admin/OutgoingGuests";
 import IncomingGuests from "../components/Admin/IncomingGuests";
 import RequestList from "./../components/RequestsPage/RequestList";
 import Panel from "./../components/Common/Panel";
+import { GetBookingConfig } from "./../components/RequestsPage/GetBookingConfig";
 
 
 export default function HostPage() {
@@ -45,6 +46,7 @@ export default function HostPage() {
                         <Panel title="Förfrågningar">
                             <RequestList
                                 compact={true}
+                                config={GetBookingConfig("host")}
                             />
                         </Panel>
                         <IncomingGuests />


### PR DESCRIPTION
We have uppdated configuration for request list to support both caseworker and host with the same list. When the change was made the compact list in the Host overview page was missed and the config for urls etc was empty and the overview pages was not loading. This patch fixes the issue.

Changes:
- Restructured setting config to own function
- Changes to HostPage to use the new function to get correct configuration
- Changes existing RequestPage to use the new function.