### PR TITLE
Added mt-16 to the sidebar Which prevents the sideboard to jump up

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -89,7 +89,7 @@ export default function Sidebar() {
   ];
 
   return (
-    <div>
+    <div className="mt-16">
       {/* Hamburger menu btn for Mobile */}
       <button
         className="fixed top-4 right-4 text-white focus:outline-none lg:hidden z-50"


### PR DESCRIPTION
#915 BUG:  Menu jumps when Bokningar is selected

Added mt-16 to the sidebar to prevent it from jumping up when the clicked on "Bokningar"