### PR TITLE
Modifications to volunteer admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ server: {
 
 ## 🔐 Accessing the Volunteer Dashboard
 
-To access the Volunteer Management Dashboard at [http://localhost:5173/admin/volunteers], ensure you're logged in as a user belonging to the `admin` or `host` group.
+To access the Volunteer Management Dashboard at [http://localhost:5173/host/volunteers], ensure you're logged in as a user belonging to the `admin` or `host` group.
 
 You can create a superuser or assign a user to the correct group:
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,11 +58,10 @@ function App() {
           {/* Host Pages */}
           <Route element={<RequireLogin allowedGroups={["host"]} />}>
             <Route path="host" element={<HostPage />} />
-            <Route
-              path="host/requests"
-              element={<RequestPageView userGroup="host" />}
-            />
+            <Route path="host/requests" element={<RequestPageView userGroup="host" />} />
             <Route path="host/products" element={<RoomPage />} />
+            {/* Volunteer Management Dashboard */}
+            <Route path="host/volunteers" element={<VolunteerManagementDashboard />} />
           </Route>
 
           {/* Caseworker Pages */}
@@ -97,40 +96,17 @@ function App() {
           </Route>
 
           {/* Volunteer Management Dashboard */}
-          <Route element={<RequireLogin allowedGroups={["admin", "host"]} />}>
-            <Route path="admin" element={<VolunteerManagementDashboard />} />
+          {/* <Route element={<RequireLogin allowedGroups={["admin", "host"]} />}> */}
+            {/* <Route path="admin" element={<VolunteerManagementDashboard />} /> */}
             {/* Volunteer Testing Page */}
-            <Route
+            {/* <Route
               path="admin/volunteers"
               element={<VolunteerManagementDashboard />}
-            />
-          </Route>
+            /> */}
+          {/* </Route> */}
+
           {/* Invalid path */}
           <Route path="*" element={<ErrorPage />} />
-        </Route>
-
-        {/* Host Pages */}
-        <Route element={<RequireLogin allowedGroups={["host"]} />}>
-          <Route path="host" element={<HostPage />} />
-          <Route path="host/requests" element={<RequestPageView userGroup="host" />} />
-          <Route path="host/products" element={<RoomPage />} />
-        </Route>
-
-        {/* Caseworker Pages */}
-        <Route element={<RequireLogin allowedGroups={["caseworker"]} />}>
-          <Route path="caseworker" element={<CaseworkerPage />} />
-          <Route path="caseworker/requests" element={<RequestPageView userGroup="caseworker" />} />
-          <Route path="caseworker/statistics" element={<CaseworkerStatisticsPage userGroup="caseworker" />} />
-        </Route>
-
-        {/* Volunteer Pages */}
-        <Route element={<RequireLogin allowedGroups={["volunteer"]} />}>
-          <Route path="volunteer" element={<VolunteerPage />} />
-          <Route path="volunteer/requests" element={<RequestPageView userGroup="volunteer" />} />
-        </Route>
-
-        {/* Invalid path */}
-        <Route path="*" element={<ErrorPage />}>
         </Route>
       </Routes >
       <ToastContainer position="top-right" autoClose={3000} />

--- a/src/components/Sidebar/GetMenuItems.js
+++ b/src/components/Sidebar/GetMenuItems.js
@@ -19,9 +19,10 @@ export default function GetMenuItems(userGroup) {
         { icon: FaBell, label: "Förfrågningar", sideBarLink: "host/requests" },
         { icon: FaCalendarAlt, label: "Kalender" },
         { icon: FaRandom, label: "Mina Rum", sideBarLink: "host/products" },
-        { icon: FaRandom, label: "Härberget" },
-        { icon: FaUser, label: "Gäster" },
-        { icon: FaReceipt, label: "Fakturering" },
+        //{ icon: FaRandom, label: "Härberget" },
+        //{ icon: FaUser, label: "Gäster" },
+        //{ icon: FaReceipt, label: "Fakturering" },
+        { icon: FaUser, label: "Volontärhantering", sideBarLink: "host/volunteers" },
     ];
 
     const caseworkerSidebarItemsTop = [

--- a/src/components/Sidebar/GetMenuItems.js
+++ b/src/components/Sidebar/GetMenuItems.js
@@ -1,6 +1,6 @@
 import {
     FaChartPie,
-    FaReceipt,
+    //FaReceipt,
     FaBell,
     FaUser,
     FaRandom,

--- a/src/config/roleRoutes.js
+++ b/src/config/roleRoutes.js
@@ -1,5 +1,5 @@
 export const roleToRouteMap = {
-  admin: "/admin/volunteers",
+  admin: "/host/volunteers",
   volunteer: "/volunteer",
   host: "/host",
   caseworker: "/caseworker",


### PR DESCRIPTION
Changes:
- Changed path to /host/volunteers, reason for the change is that /admin will conflict with django admin and can cause strange behaviour
- Removed duplicate Host, Caseworker and Volunteer routes from the App.jsx file
- Adds a menu item for volunteer management for host